### PR TITLE
Reactive initial value

### DIFF
--- a/src/app/date-picker/date-picker.directive.ts
+++ b/src/app/date-picker/date-picker.directive.ts
@@ -1,4 +1,3 @@
-import {UtilsService} from '../common/services/utils/utils.service';
 import {ECalendarValue} from '../common/types/calendar-value-enum';
 import {CalendarType} from './../common/types/calendar-type';
 import {IDatePickerDirectiveConfig} from './date-picker-directive-config.model';
@@ -35,9 +34,6 @@ export class DatePickerDirective implements OnInit {
   @Input('dpDayPicker') set config(config: IDatePickerDirectiveConfig) {
     this._config = this.service.getConfig(config, this.viewContainerRef.element, this.attachTo);
     this.updateDatepickerConfig();
-    if (this.datePicker) {
-      this.datePicker.init();
-    }
   }
 
   get attachTo(): ElementRef | string {
@@ -48,9 +44,6 @@ export class DatePickerDirective implements OnInit {
     this._attachTo = attachTo;
     this._config = this.service.getConfig(this.config, this.viewContainerRef.element, this.attachTo);
     this.updateDatepickerConfig();
-    if (this.datePicker) {
-      this.datePicker.init();
-    }
   }
 
   get theme(): string {
@@ -81,15 +74,14 @@ export class DatePickerDirective implements OnInit {
   constructor(public viewContainerRef: ViewContainerRef,
               public componentFactoryResolver: ComponentFactoryResolver,
               @Optional() public formControl: NgControl,
-              public service: DatePickerDirectiveService,
-              public utilsService: UtilsService) {
+              public service: DatePickerDirectiveService) {
   }
 
   ngOnInit(): void {
     this.datePicker = this.createDatePicker();
     this.api = this.datePicker.api;
-    this.attachModelToDatePicker();
     this.updateDatepickerConfig();
+    this.attachModelToDatePicker();
     this.datePicker.theme = this.theme;
   }
 
@@ -102,11 +94,7 @@ export class DatePickerDirective implements OnInit {
     if (!this.formControl) {
       return;
     }
-    this.updateDatepickerConfig();
-    if (this.datePicker) {
-      this.datePicker.init();
-      this.datePicker.onViewDateChange(this.formControl.value);
-    }
+    this.datePicker.onViewDateChange(this.formControl.value);
     this.formControl.valueChanges.subscribe(value => {
       if (value !== this.datePicker.inputElementValue) {
         this.datePicker.onViewDateChange(value);
@@ -134,6 +122,7 @@ export class DatePickerDirective implements OnInit {
     if (this.datePicker) {
       this.datePicker.type = this.type || 'day';
       this.datePicker.config = this.config;
+      this.datePicker.init();
     }
   }
 }

--- a/src/app/date-picker/date-picker.directive.ts
+++ b/src/app/date-picker/date-picker.directive.ts
@@ -1,3 +1,5 @@
+import {UtilsService} from '../common/services/utils/utils.service';
+import {ECalendarValue} from '../common/types/calendar-value-enum';
 import {CalendarType} from './../common/types/calendar-type';
 import {IDatePickerDirectiveConfig} from './date-picker-directive-config.model';
 import {DatePickerDirectiveService} from './date-picker-directive.service';
@@ -79,7 +81,8 @@ export class DatePickerDirective implements OnInit {
   constructor(public viewContainerRef: ViewContainerRef,
               public componentFactoryResolver: ComponentFactoryResolver,
               @Optional() public formControl: NgControl,
-              public service: DatePickerDirectiveService) {
+              public service: DatePickerDirectiveService,
+              public utilsService: UtilsService) {
   }
 
   ngOnInit(): void {
@@ -98,6 +101,11 @@ export class DatePickerDirective implements OnInit {
   attachModelToDatePicker() {
     if (!this.formControl) {
       return;
+    }
+    this.updateDatepickerConfig();
+    if (this.datePicker) {
+      this.datePicker.init();
+      this.datePicker.onViewDateChange(this.formControl.value);
     }
     this.formControl.valueChanges.subscribe(value => {
       if (value !== this.datePicker.inputElementValue) {

--- a/src/app/demo/demo/demo.component.html
+++ b/src/app/demo/demo/demo.component.html
@@ -152,7 +152,7 @@
                 [theme]="material ? 'dp-material' : ''"
                 formControlName="datePicker"
                 [placeholder]="placeholder"
-                [disabled]="disabled"
+                (ngModelChange)="date = $event; log($event)"
                 [required]="required"
                 />
           <div class="dp-validations">

--- a/src/app/demo/demo/demo.component.ts
+++ b/src/app/demo/demo/demo.component.ts
@@ -79,7 +79,7 @@ export class DemoComponent {
   modeChanged() {
     this.config.hideInputContainer = false;
     this.config.inputElementContainer = undefined;
-    this.formGroup.setValue({ datePicker: this.date });
+    this.formGroup.get('datePicker').setValue(this.date);
   }
 
   validatorsChanged() {

--- a/src/app/demo/demo/demo.component.ts
+++ b/src/app/demo/demo/demo.component.ts
@@ -30,7 +30,7 @@ export class DemoComponent {
   placeholder: string = 'Choose a date...';
 
   formGroup: FormGroup = new FormGroup({
-    datePicker: new FormControl(this.date, [
+    datePicker: new FormControl({ value: this.date, disabled: this.disabled }, [
       this.required ? Validators.required : () => undefined,
       control => this.validationMinDate && this.config && moment(control.value, this.config.format).isBefore(this.validationMinDate)
         ? {minDate: 'minDate Invalid'} : undefined,
@@ -79,6 +79,7 @@ export class DemoComponent {
   modeChanged() {
     this.config.hideInputContainer = false;
     this.config.inputElementContainer = undefined;
+    this.formGroup.setValue({ datePicker: this.date });
   }
 
   validatorsChanged() {


### PR DESCRIPTION
This is to fix a bug where any initial value set in a reactive form is ignored by the `[dpDayPicker]` directive.