### PR TITLE
day-calendar: add new emitter for onMonthSelect

### DIFF
--- a/src/app/day-calendar/day-calendar.component.ts
+++ b/src/app/day-calendar/day-calendar.component.ts
@@ -56,6 +56,7 @@ export class DayCalendarComponent implements OnInit, OnChanges, ControlValueAcce
   @Input() maxDate: Moment;
   @HostBinding('class') @Input() theme: string;
   @Output() onSelect: EventEmitter<IDay> = new EventEmitter();
+  @Output() onMonthSelect: EventEmitter<IMonth> = new EventEmitter();
   @Output() onNavHeaderBtnClick: EventEmitter<ECalendarType> = new EventEmitter();
 
   CalendarType = ECalendarType;
@@ -221,6 +222,7 @@ export class DayCalendarComponent implements OnInit, OnChanges, ControlValueAcce
     this.currentCalendarType = ECalendarType.Day;
     this.weeks = this.dayCalendarService
       .generateMonthArray(this.componentConfig, this.currentDateView, this.selected);
+    this.onMonthSelect.emit(month);
   }
 
   moveCalendarsBy(current: Moment, amount: number, granularity: moment.unitOfTime.Base = 'month') {


### PR DESCRIPTION
In order to get information such as which days should be disabled for a given month, it is important to know when the month is changed and what the new selected month is in order to fetch and display the correct data.

This new `onMonthSelect` emitter adds a new output to the inline day-calendar component.