### PR TITLE
Datepicker in directive mode opens on previously selected date

### DIFF
--- a/src/app/date-picker/date-picker.directive.ts
+++ b/src/app/date-picker/date-picker.directive.ts
@@ -28,7 +28,11 @@ export class DatePickerDirective implements OnInit {
   private _type: CalendarType = 'day';
   private _minDate: Moment | string;
   private _maxDate: Moment | string;
+<<<<<<< HEAD
   private _previouslySelectedDate: string = "";
+=======
+  private _previouslySelectedDate: string = '';
+>>>>>>> Datepicker in directive mode opens on previously selected date
 
   get config(): IDatePickerDirectiveConfig {
     return this._config;
@@ -129,12 +133,12 @@ export class DatePickerDirective implements OnInit {
     });
 
     this.datePicker.registerOnChange((value) => {
-      if(value != null){
-        let formattedValue = value.format(this.config.format);
-        if(formattedValue !== this._previouslySelectedDate)
-        this.formControl.control.setValue(formattedValue);
+      if (value != null) {
+        const formattedValue = value.format(this.config.format);
+        if (formattedValue !== this._previouslySelectedDate) {
+          this.formControl.control.setValue(formattedValue);
+        }
       }
-      
       const errors = this.datePicker.validateFn(value);
       if (errors) {
         this.formControl.control.setErrors(errors);

--- a/src/app/date-picker/date-picker.directive.ts
+++ b/src/app/date-picker/date-picker.directive.ts
@@ -28,6 +28,7 @@ export class DatePickerDirective implements OnInit {
   private _type: CalendarType = 'day';
   private _minDate: Moment | string;
   private _maxDate: Moment | string;
+  private _previouslySelectedDate: string = "";
 
   get config(): IDatePickerDirectiveConfig {
     return this._config;
@@ -123,13 +124,17 @@ export class DatePickerDirective implements OnInit {
 
     this.datePicker.onViewDateChange(this.formControl.value);
     this.formControl.valueChanges.subscribe(value => {
-      if (value !== this.datePicker.inputElementValue) {
+        this._previouslySelectedDate = value;
         this.datePicker.onViewDateChange(value);
-      }
     });
 
     this.datePicker.registerOnChange((value) => {
-      this.formControl.control.setValue(this.datePicker.inputElementValue);
+      if(value != null){
+        let formattedValue = value.format(this.config.format);
+        if(formattedValue !== this._previouslySelectedDate)
+        this.formControl.control.setValue(formattedValue);
+      }
+      
       const errors = this.datePicker.validateFn(value);
       if (errors) {
         this.formControl.control.setErrors(errors);

--- a/src/app/date-picker/date-picker.directive.ts
+++ b/src/app/date-picker/date-picker.directive.ts
@@ -28,11 +28,8 @@ export class DatePickerDirective implements OnInit {
   private _type: CalendarType = 'day';
   private _minDate: Moment | string;
   private _maxDate: Moment | string;
-<<<<<<< HEAD
-  private _previouslySelectedDate: string = "";
-=======
   private _previouslySelectedDate: string = '';
->>>>>>> Datepicker in directive mode opens on previously selected date
+
 
   get config(): IDatePickerDirectiveConfig {
     return this._config;


### PR DESCRIPTION
I was able to spend a little more time with this problem I reported and I managed to find solution. Generally there was a problem, because when condition mentioned by @isaiev (https://github.com/vlio20/angular-datepicker/blob/master/src/app/date-picker/date-picker.directive.ts#L126) was tested, `this.datePicker.inputElementValue` was already having new value. I introduced new variable to store previously selected value and rearranged code a little bit to avoid infinite recurrence.