### PR TITLE
Added year-picker calendar, with a demonstration on the Demo page

### DIFF
--- a/e2e/app.po.ts
+++ b/e2e/app.po.ts
@@ -14,6 +14,7 @@ export class DemoPage {
   datePickerPopup = $(this.popupSelector);
   dayCalendar = $(`${this.popupSelector} dp-day-calendar`);
   dayCalendarContainer = $(`${this.popupSelector} dp-day-calendar .dp-day-calendar-container`);
+  yearPickerInput = $('#yearPicker input');
   monthPickerInput = $('#monthPicker input');
   monthCalendar = $(`${this.popupSelector} dp-month-calendar`);
   monthWeeks = $$(`${this.popupSelector} .dp-calendar-week`);
@@ -60,7 +61,6 @@ export class DemoPage {
   enableRequiredValidationRadio = $('#enableRequiredRadio');
   disableRequiredValidationRadio = $('#disableRequiredRadio');
   requiredValidationMsg = $('#requiredValidation');
-  formatValidationMsg = $('#formatValidation');
   reactiveRequiredValidationMsg = $('#reactiveRequiredValidation');
   reactiveMinDateValidationMsg = $('#reactiveMinDateValidation');
   reactiveMaxDateValidationMsg = $('#reactiveMaxDateValidation');
@@ -107,8 +107,6 @@ export class DemoPage {
   showMultipleYearsNavigation = $('#showMultipleYearsNavigation');
   hideMultipleYearsNavigation = $('#hideMultipleYearsNavigation');
   multipleYearsNavigateBy = $('#multipleYearsNavigateBy');
-  showInputRadio = $('#showInputRadio');
-  hideInputRadio = $('#hideInputRadio');
 
   hourUpBtn = $(`${this.popupSelector} .dp-time-select-control-hours > .dp-time-select-control-up`);
   hourDownBtn = $(`${this.popupSelector} .dp-time-select-control-hours > .dp-time-select-control-down`);
@@ -131,8 +129,9 @@ export class DemoPage {
   dayPickerMenu = $('#dayPickerMenu');
   dayInlineMenu = $('#dayInlineMenu');
   dayDirectiveMenu = $('#dayDirectiveMenu');
-  dayDirectiveReactiveMenu = $('#dayDirectiveReactiveMenu');
+  dayDirectiveReactive = $('#dayDirectiveReactive');
   monthPickerMenu = $('#monthPickerMenu');
+  yearPickerMenu = $('#yearPickerMenu');
   monthInlineMenu = $('#monthInlineMenu');
   monthDirectiveMenu = $('#monthDirectiveMenu');
   timePickerMenu = $('#timePickerMenu');
@@ -148,10 +147,6 @@ export class DemoPage {
   clickOnBody() {
     this.body.click();
     this.body.click();
-  }
-
-  scrollIntoView(el, top = false) {
-    browser.executeScript(`arguments[0].scrollIntoView(${top})`, el.getWebElement());
   }
 
   clickOnDayButton(text: string) {

--- a/src/app/common/types/calendar-mode-enum.ts
+++ b/src/app/common/types/calendar-mode-enum.ts
@@ -2,5 +2,6 @@ export enum ECalendarMode {
   Day,
   DayTime,
   Month,
-  Time
+  Time,
+  Year
 }

--- a/src/app/date-picker.module.ts
+++ b/src/app/date-picker.module.ts
@@ -7,6 +7,7 @@ import {DatePickerComponent} from './date-picker/date-picker.component';
 import {DatePickerDirective} from './date-picker/date-picker.directive';
 import {DayCalendarComponent} from './day-calendar/day-calendar.component';
 import {MonthCalendarComponent} from './month-calendar/month-calendar.component';
+import {YearCalendarComponent} from './year-calendar/year-calendar.component';
 import {TimeSelectComponent} from './time-select/time-select.component';
 import {CalendarNavComponent} from './calendar-nav/calendar-nav.component';
 import {DayTimeCalendarComponent} from './day-time-calendar/day-time-calendar.component';
@@ -16,6 +17,8 @@ export {DayCalendarComponent} from './day-calendar/day-calendar.component';
 export {DayTimeCalendarComponent} from './day-time-calendar/day-time-calendar.component';
 export {TimeSelectComponent} from './time-select/time-select.component';
 export {MonthCalendarComponent} from './month-calendar/month-calendar.component';
+export {YearCalendarComponent} from './year-calendar/year-calendar.component';
+
 
 @NgModule({
   providers: [
@@ -27,6 +30,7 @@ export {MonthCalendarComponent} from './month-calendar/month-calendar.component'
     DatePickerDirective,
     DayCalendarComponent,
     MonthCalendarComponent,
+    YearCalendarComponent,
     CalendarNavComponent,
     TimeSelectComponent,
     DayTimeCalendarComponent
@@ -42,6 +46,7 @@ export {MonthCalendarComponent} from './month-calendar/month-calendar.component'
     DatePickerComponent,
     DatePickerDirective,
     MonthCalendarComponent,
+    YearCalendarComponent,
     DayCalendarComponent,
     TimeSelectComponent,
     DayTimeCalendarComponent

--- a/src/app/date-picker/date-picker-config.model.ts
+++ b/src/app/date-picker/date-picker-config.model.ts
@@ -1,10 +1,12 @@
 import {TDrops, TOpens} from '../common/types/poistions.type';
 import {IDayCalendarConfig} from '../day-calendar/day-calendar-config.model';
 import {IMonthCalendarConfig} from '../month-calendar/month-calendar-config';
+import {IYearCalendarConfig} from '../year-calendar/year-calendar-config';
 import {ITimeSelectConfig} from '../time-select/time-select-config.model';
 
 export interface IDatePickerConfig extends IDayCalendarConfig,
                                            IMonthCalendarConfig,
+                                           IYearCalendarConfig,
                                            ITimeSelectConfig {
   closeOnSelect?: boolean;
   closeOnSelectDelay?: number;

--- a/src/app/date-picker/date-picker-directive-config.model.ts
+++ b/src/app/date-picker/date-picker-directive-config.model.ts
@@ -1,9 +1,10 @@
 import {TDrops, TOpens} from '../common/types/poistions.type';
 import {IDayCalendarConfig} from '../day-calendar/day-calendar-config.model';
 import {IMonthCalendarConfig} from '../month-calendar/month-calendar-config';
+import {IYearCalendarConfig} from '../year-calendar/year-calendar-config';
 import {ITimeSelectConfig} from '../time-select/time-select-config.model';
 
-export interface IDatePickerDirectiveConfig extends IDayCalendarConfig, IMonthCalendarConfig, ITimeSelectConfig {
+export interface IDatePickerDirectiveConfig extends IDayCalendarConfig, IMonthCalendarConfig, IYearCalendarConfig, ITimeSelectConfig {
   closeOnSelect?: boolean;
   closeOnSelectDelay?: number;
   onOpenDelay?: number;

--- a/src/app/date-picker/date-picker.component.html
+++ b/src/app/date-picker/date-picker.component.html
@@ -1,5 +1,5 @@
 <div [ngClass]="{'dp-open': areCalendarsShown}">
-  <div [hidden]="componentConfig.hideInputContainer" class="dp-input-container">
+  <div *ngIf="!componentConfig.hideInputContainer" class="dp-input-container">
     <input type="text"
            class="dp-picker-input"
            [placeholder]="placeholder"
@@ -37,6 +37,15 @@
                          (onSelect)="dateSelected($event, 'month')"
                          [theme]="theme">
       </dp-month-calendar>
+
+      <dp-year-calendar #yearCalendar
+                         *ngSwitchCase="'year'"
+                         [config]="dayCalendarConfig"
+                         [ngModel]="_selected"
+                         [displayDate]="currentDateView"
+                         (onSelect)="dateSelected($event, 'year')"
+                         [theme]="theme">
+      </dp-year-calendar>
 
       <dp-time-select #timeSelect
                       *ngSwitchCase="'time'"

--- a/src/app/demo/demo/demo.component.html
+++ b/src/app/demo/demo/demo.component.html
@@ -27,12 +27,16 @@
            [ngClass]="{'dp-active-item': pickerMode == 'dayDirective'}">Day Picker directive</a>
       </li>
       <li>
-        <a id="dayDirectiveReactiveMenu" href="#" (click)="modeChanged('dayDirectiveReactive')"
+        <a id="dayDirectiveReactive" href="#" (click)="modeChanged('dayDirectiveReactive')"
            [ngClass]="{'dp-active-item': pickerMode == 'dayDirectiveReactive'}">Day Picker directive Reactive</a>
       </li>
       <li>
         <a id="monthPickerMenu" href="#" (click)="modeChanged('monthPicker')"
            [ngClass]="{'dp-active-item': pickerMode == 'monthPicker'}">Month Picker</a>
+      </li>
+      <li>
+        <a id="yearPickerMenu" href="#" (click)="modeChanged('yearPicker')"
+           [ngClass]="{'dp-active-item': pickerMode == 'yearPicker'}">Year Picker</a>
       </li>
       <li>
         <a id="monthInlineMenu" href="#" (click)="modeChanged('monthInline')"
@@ -62,14 +66,13 @@
                                              'dp-inline-day': pickerMode == 'dayInline',
                                              'dp-inline-month': pickerMode == 'monthInline',
                                              'dp-inline-time': pickerMode == 'timeInline',
+                                             'dp-inline-year': pickerMode == 'yearInline',
                                              'dp-inline-day-time': pickerMode == 'daytimeInline'}">
 
-    <form #donateForm class="dp-donate-btn" action="https://www.paypal.com/cgi-bin/webscr" method="post"
-          target="_blank">
+    <form #donateForm class="dp-donate-btn" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
       <input type="hidden" name="cmd" value="_s-xclick">
       <input type="hidden" name="hosted_button_id" value="8ZR2S5XYJ6WLJ">
-      <input (click)="donateClicked()" type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif"
-             border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+      <input (click)="donateClicked()" type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
       <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
     </form>
 
@@ -78,90 +81,13 @@
     <!--<div>{{form.form.dirty}}</div>-->
 
     <form #form="ngForm">
-      <div class="dp-picker-time-picker" *ngIf="pickerMode === 'daytimePicker'">
-        <dp-date-picker id="daytimePicker"
-                        name="daytimePicker"
-                        #datePicker
-                        #daytimePicker="ngModel"
-                        [(ngModel)]="date"
-                        (onChange)="log($event)"
-                        [mode]="'daytime'"
-                        [displayDate]="displayDate"
-                        (open)="opened()"
-                        (close)="closed()"
-                        [disabled]="disabled"
-                        [minDate]="validationMinDate"
-                        [maxDate]="validationMaxDate"
-                        [required]="required"
-                        [placeholder]="placeholder"
-                        [config]="config"
-                        [theme]="material ? 'dp-material' : ''">
-        </dp-date-picker>
-
-        <div class="dp-validations">
-          <div id="requiredValidation" *ngIf="daytimePicker.errors?.required">required</div>
-          <div id="formatValidation" *ngIf="daytimePicker.errors?.format">invalid format</div>
-          <div id="minDateValidation" *ngIf="daytimePicker.errors?.minDate">minDate invalid</div>
-          <div id="maxDateValidation" *ngIf="daytimePicker.errors?.maxDate">maxDate invalid</div>
-        </div>
-      </div>
-
-      <div class="dp-inline-day-time" *ngIf="pickerMode === 'daytimeInline'">
-        <dp-day-time-calendar
-            name="daytimeInline"
-            #daytimeInline="ngModel"
-            [theme]="material ? 'dp-material' : ''"
-            [(ngModel)]="date"
-            (ngModelChange)="log($event)"
-            [minDate]="validationMinDate"
-            [maxDate]="validationMaxDate"
-            [config]="config">
-        </dp-day-time-calendar>
-
-        <div class="dp-validations">
-          <div id="daytimeInlineRequiredValidation" *ngIf="daytimeInline.errors?.required">
-            required
-          </div>
-          <div id="daytimeInlineMinDateValidation" *ngIf="daytimeInline.errors?.minDate">minDate
-            invalid
-          </div>
-          <div id="daytimeInlineMaxDateValidation" *ngIf="daytimeInline.errors?.maxDate">maxDate
-            invalid
-          </div>
-        </div>
-      </div>
-
-      <div class="dp-picker-day-time-directive" id="daytimeDirective" *ngIf="pickerMode === 'daytimeDirective'">
-        <input [dpDayPicker]="config"
-               name="daytimePickerDir"
-               #dateDirectivePicker="dpDayPicker"
-               #daytimeDirectivePickerModel="ngModel"
-               [theme]="material ? 'dp-material' : ''"
-               mode="daytime"
-               [(ngModel)]="date"
-               (open)="opened()"
-               (close)="closed()"
-               [placeholder]="placeholder"
-               [minDate]="validationMinDate"
-               [maxDate]="validationMaxDate"
-               [disabled]="disabled"
-               [required]="required"
-               (onChange)="log($event)"/>
-        <div class="dp-validations">
-          <div id="requiredValidation" *ngIf="daytimeDirectivePickerModel.errors?.required">required</div>
-          <div id="formatValidation" *ngIf="daytimeDirectivePickerModel.errors?.format">invalid format</div>
-          <div *ngIf="daytimeDirectivePickerModel.errors?.minDate">minDate invalid</div>
-          <div *ngIf="daytimeDirectivePickerModel.errors?.maxDate">maxDate invalid</div>
-        </div>
-      </div>
-
       <div class="dp-picker-day" *ngIf="pickerMode === 'dayPicker'">
         <dp-date-picker id="datePicker"
                         name="datePicker"
                         #datePicker
                         #datePickerModel="ngModel"
                         [(ngModel)]="date"
-                        (onChange)="log($event)"
+                        (ngModelChange)="log($event)"
                         [mode]="'day'"
                         [displayDate]="displayDate"
                         [disabled]="disabled"
@@ -174,13 +100,12 @@
                         [config]="config"
                         [theme]="material ? 'dp-material' : ''">
         </dp-date-picker>
-        <div class="dp-validations" *ngIf="datePickerModel.errors">
-          <div id="requiredValidation" *ngIf="datePickerModel.errors.required">required</div>
-          <div id="formatValidation" *ngIf="datePickerModel.errors.format">invalid format
+        <div class="dp-validations">
+          <div id="requiredValidation" *ngIf="datePickerModel.errors && datePickerModel.errors.required">required</div>
+          <div *ngIf="datePickerModel.errors && datePickerModel.errors.format">format invalid</div>
+          <div id="minDateValidation" *ngIf="datePickerModel.errors && datePickerModel.errors.minDate">minDate invalid
           </div>
-          <div id="minDateValidation" *ngIf="datePickerModel.errors.minDate">minDate invalid
-          </div>
-          <div id="maxDateValidation" *ngIf="datePickerModel.errors.maxDate">maxDate invalid
+          <div id="maxDateValidation" *ngIf="datePickerModel.errors && datePickerModel.errors.maxDate">maxDate invalid
           </div>
         </div>
       </div>
@@ -219,44 +144,13 @@
                [maxDate]="validationMaxDate"
                [disabled]="disabled"
                [required]="required"
-               (onChange)="log($event)"/>
+               (ngModelChange)="log($event)"/>
         <div class="dp-validations">
           <div id="requiredValidation" *ngIf="dateDirectivePickerModel.errors?.required || false">required</div>
-          <div id="formatValidation" *ngIf="dateDirectivePickerModel.errors && dateDirectivePickerModel.errors.format">
-            invalid format
-          </div>
+          <div *ngIf="dateDirectivePickerModel.errors?.format || false">format invalid</div>
           <div *ngIf="dateDirectivePickerModel.errors?.minDate">minDate invalid</div>
           <div *ngIf="dateDirectivePickerModel.errors?.maxDate">maxDate invalid</div>
         </div>
-      </div>
-
-      <div class="dp-picker-day-directive" id="datePickerDirDayReactive" *ngIf="pickerMode === 'dayDirectiveReactive'">
-        <form [formGroup]="formGroup">
-          <input [dpDayPicker]="config"
-                 name="datePicker"
-                 #dateDirectivePicker="dpDayPicker"
-                 [theme]="material ? 'dp-material' : ''"
-                 formControlName="datePicker"
-                 [placeholder]="placeholder"
-                 (onChange)="date = $event; log($event)"
-                 [required]="required"
-                 (open)="opened()"
-                 (close)="closed()"/>
-          <div class="dp-validations" *ngIf="formGroup.get('datePicker').touched">
-            <div id="reactiveRequiredValidation"
-                 *ngIf="formGroup.get('datePicker').hasError('required')">
-              required
-            </div>
-            <div id="formatValidation" *ngIf="formGroup.get('datePicker').hasError('format')">
-              invalid format
-            </div>
-            <div id="reactiveMinDateValidation"
-                 *ngIf="formGroup.get('datePicker').hasError('minDate')">minDate invalid
-            </div>
-            <div id="reactiveMaxDateValidation" *ngIf="formGroup.get('datePicker').hasError('maxDate')">maxDate invalid
-            </div>
-          </div>
-        </form>
       </div>
 
       <div class="dp-picker-month" *ngIf="pickerMode === 'monthPicker'">
@@ -265,7 +159,7 @@
                         #datePicker
                         #monthPicker="ngModel"
                         [(ngModel)]="date"
-                        (onChange)="log($event)"
+                        (ngModelChange)="log($event)"
                         [mode]="'month'"
                         [displayDate]="displayDate"
                         (open)="opened()"
@@ -281,8 +175,7 @@
         <div class="dp-validations">
           <div id="monthPickerRequiredValidation" *ngIf="monthPicker.errors && monthPicker.errors.required">required
           </div>
-          <div id="formatValidation" *ngIf="monthPicker.errors && monthPicker.errors.format">invalid format
-          </div>
+          <div *ngIf="monthPicker.errors && monthPicker.errors.format">format invalid</div>
           <div id="monthPickerMinDateValidation" *ngIf="monthPicker.errors && monthPicker.errors.minDate">minDate
             invalid
           </div>
@@ -290,6 +183,28 @@
             invalid
           </div>
         </div>
+      </div>
+
+      <div class="dp-picker-year" *ngIf="pickerMode === 'yearPicker'">
+        <dp-date-picker id="yearPicker"
+                        name="yearPicker"
+                        #datePicker
+                        #monthPicker="ngModel"
+                        [(ngModel)]="date"
+                        (ngModelChange)="log($event)"
+                        [mode]="'year'"
+                        [displayDate]="displayDate"
+                        (open)="opened()"
+                        (close)="closed()"
+                        [disabled]="disabled"
+                        [minDate]="validationMinDate"
+                        [maxDate]="validationMaxDate"
+                        [required]="required"
+                        [placeholder]="placeholder"
+                        [config]="config"
+                        [theme]="material ? 'dp-material' : ''">
+        </dp-date-picker>
+        
       </div>
 
       <div class="dp-inline-month" *ngIf="pickerMode === 'monthInline'">
@@ -304,6 +219,7 @@
             [required]="required"
             [config]="config">
         </dp-month-calendar>
+
         <div class="dp-validations">
           <div id="monthInlineRequiredValidation" *ngIf="monthInline.errors && monthInline.errors.required">required
           </div>
@@ -316,35 +232,13 @@
         </div>
       </div>
 
-      <div class="dp-picker-month-directive" id="datePickerDirMonth" *ngIf="pickerMode === 'monthDirective'">
-        <input [dpDayPicker]="config"
-               name="datePicker"
-               #dateDirectivePicker="dpDayPicker"
-               #dateDirectivePickerModel="ngModel"
-               [theme]="material ? 'dp-material' : ''"
-               mode="month"
-               [(ngModel)]="date"
-               (open)="opened()"
-               (close)="closed()"
-               [placeholder]="placeholder"
-               [disabled]="disabled"
-               [required]="required"
-               (onChange)="log($event)"/>
-        <div class="dp-validations">
-          <div id="requiredValidation" *ngIf="dateDirectivePickerModel.errors?.required || false">required</div>
-          <div id="formatValidation" *ngIf="dateDirectivePickerModel.errors && dateDirectivePickerModel.errors.format">
-            invalid format
-          </div>
-        </div>
-      </div>
-
       <div class="dp-picker-time" *ngIf="pickerMode === 'timePicker'">
         <dp-date-picker id="timePicker"
                         name="timePicker"
                         #datePicker
                         #timePicker="ngModel"
                         [(ngModel)]="date"
-                        (onChange)="log($event)"
+                        (ngModelChange)="log($event)"
                         [mode]="'time'"
                         (open)="opened()"
                         (close)="closed()"
@@ -359,8 +253,7 @@
         <div class="dp-validations">
           <div id="timePickerRequiredValidation" *ngIf="timePicker.errors && timePicker.errors.required">required
           </div>
-          <div id="formatValidation" *ngIf="timePicker.errors && timePicker.errors.format">invalid format
-          </div>
+          <div *ngIf="timePicker.errors && timePicker.errors.format">format invalid</div>
           <div id="timePickerMinTimeValidation" *ngIf="timePicker.errors && timePicker.errors.minTime">minTime
             invalid
           </div>
@@ -396,6 +289,133 @@
         </div>
       </div>
 
+      <div class="dp-picker-time-picker" *ngIf="pickerMode === 'daytimePicker'">
+        <dp-date-picker id="daytimePicker"
+                        name="daytimePicker"
+                        #datePicker
+                        #daytimePicker="ngModel"
+                        [(ngModel)]="date"
+                        (ngModelChange)="log($event)"
+                        [mode]="'daytime'"
+                        [displayDate]="displayDate"
+                        (open)="opened()"
+                        (close)="closed()"
+                        [disabled]="disabled"
+                        [minDate]="validationMinDate"
+                        [maxDate]="validationMaxDate"
+                        [required]="required"
+                        [placeholder]="placeholder"
+                        [config]="config"
+                        [theme]="material ? 'dp-material' : ''">
+        </dp-date-picker>
+
+        <div class="dp-validations">
+          <div id="requiredValidation" *ngIf="daytimePicker.errors && daytimePicker.errors.required">required
+          </div>
+          <div *ngIf="daytimePicker.errors && daytimePicker.errors.format">format invalid</div>
+          <div id="minDateValidation" *ngIf="daytimePicker.errors && daytimePicker.errors.minDate">minDate
+            invalid
+          </div>
+          <div id="maxDateValidation" *ngIf="daytimePicker.errors && daytimePicker.errors.maxDate">maxDate
+            invalid
+          </div>
+        </div>
+      </div>
+
+      <div class="dp-inline-day-time" *ngIf="pickerMode === 'daytimeInline'">
+        <dp-day-time-calendar
+            name="daytimeInline"
+            #daytimeInline="ngModel"
+            [theme]="material ? 'dp-material' : ''"
+            [(ngModel)]="date"
+            (ngModelChange)="log($event)"
+            [minDate]="validationMinDate"
+            [maxDate]="validationMaxDate"
+            [config]="config">
+        </dp-day-time-calendar>
+
+        <div class="dp-validations">
+          <div id="daytimeInlineRequiredValidation" *ngIf="daytimeInline.errors && daytimeInline.errors.required">
+            required
+          </div>
+          <div id="daytimeInlineMinDateValidation" *ngIf="daytimeInline.errors && daytimeInline.errors.minDate">minDate
+            invalid
+          </div>
+          <div id="daytimeInlineMaxDateValidation" *ngIf="daytimeInline.errors && daytimeInline.errors.maxDate">maxDate
+            invalid
+          </div>
+        </div>
+      </div>
+
+      <div class="dp-picker-day-directive" id="datePickerDirDayReactive" *ngIf="pickerMode === 'dayDirectiveReactive'">
+        <form [formGroup]="formGroup">
+          <input [dpDayPicker]="config"
+                 name="datePicker"
+                 #dateDirectivePicker="dpDayPicker"
+                 [theme]="material ? 'dp-material' : ''"
+                 formControlName="datePicker"
+                 [placeholder]="placeholder"
+                 (ngModelChange)="date = $event; log($event)"
+                 [required]="required"
+                 (open)="opened()"
+                 (close)="closed()"/>
+          <div class="dp-validations">
+            <div id="reactiveRequiredValidation"
+                 *ngIf="formGroup.get('datePicker').hasError('required') && formGroup.get('datePicker').touched">
+              required
+            </div>
+            <div id="reactiveMinDateValidation"
+                 *ngIf="formGroup.get('datePicker').hasError('minDate') && formGroup.get('datePicker').touched">minDate
+              invalid
+            </div>
+            <div id="reactiveMaxDateValidation"
+                 *ngIf="formGroup.get('datePicker').hasError('maxDate') && formGroup.get('datePicker').touched">maxDate
+              invalid
+            </div>
+          </div>
+        </form>
+      </div>
+
+      <div class="dp-picker-month-directive" id="datePickerDirMonth" *ngIf="pickerMode === 'monthDirective'">
+        <input [dpDayPicker]="config"
+               name="datePicker"
+               #dateDirectivePicker="dpDayPicker"
+               #dateDirectivePickerModel="ngModel"
+               [theme]="material ? 'dp-material' : ''"
+               mode="month"
+               [(ngModel)]="date"
+               (open)="opened()"
+               (close)="closed()"
+               [placeholder]="placeholder"
+               [disabled]="disabled"
+               [required]="required"
+               (ngModelChange)="log($event)"/>
+        <div class="dp-validations">
+          <div id="requiredValidation" *ngIf="dateDirectivePickerModel.errors?.required || false">required</div>
+          <div *ngIf="dateDirectivePickerModel.errors?.format || false">format invalid</div>
+        </div>
+      </div>
+
+      <div class="dp-picker-year-directive" id="datePickerDirYear" *ngIf="pickerMode === 'yearDirective'">
+        <input [dpDayPicker]="config"
+               name="datePicker"
+               #dateDirectivePicker="dpDayPicker"
+               #dateDirectivePickerModel="ngModel"
+               [theme]="material ? 'dp-material' : ''"
+               mode="year"
+               [(ngModel)]="date"
+               (open)="opened()"
+               (close)="closed()"
+               [placeholder]="placeholder"
+               [disabled]="disabled"
+               [required]="required"
+               (ngModelChange)="log($event)"/>
+        <div class="dp-validations">
+          <div id="requiredValidation" *ngIf="dateDirectivePickerModel.errors?.required || false">required</div>
+          <div *ngIf="dateDirectivePickerModel.errors?.format || false">format invalid</div>
+        </div>
+      </div>
+
       <div class="dp-picker-time-directive" id="timePickerDirDay" *ngIf="pickerMode === 'timeDirective'">
         <input [dpDayPicker]="config"
                name="timePickerDir"
@@ -411,14 +431,36 @@
                [maxTime]="validationMaxTime"
                [disabled]="disabled"
                [required]="required"
-               (onChange)="log($event)"/>
+               (ngModelChange)="log($event)"/>
         <div class="dp-validations">
           <div id="requiredValidation" *ngIf="timeDirectivePickerModel.errors?.required || false">required</div>
-          <div id="formatValidation" *ngIf="timeDirectivePickerModel.errors && timeDirectivePickerModel.errors.format">
-            invalid format
-          </div>
+          <div *ngIf="timeDirectivePickerModel.errors?.format || false">format invalid</div>
           <div *ngIf="timeDirectivePickerModel.errors?.minTime">minTime invalid</div>
           <div *ngIf="timeDirectivePickerModel.errors?.maxTime">maxTime invalid</div>
+        </div>
+      </div>
+
+      <div class="dp-picker-day-time-directive" id="daytimeDirective" *ngIf="pickerMode === 'daytimeDirective'">
+        <input [dpDayPicker]="config"
+               name="daytimePickerDir"
+               #dateDirectivePicker="dpDayPicker"
+               #daytimeDirectivePickerModel="ngModel"
+               [theme]="material ? 'dp-material' : ''"
+               mode="daytime"
+               [(ngModel)]="date"
+               (open)="opened()"
+               (close)="closed()"
+               [placeholder]="placeholder"
+               [minDate]="validationMinDate"
+               [maxDate]="validationMaxDate"
+               [disabled]="disabled"
+               [required]="required"
+               (ngModelChange)="log($event)"/>
+        <div class="dp-validations">
+          <div id="requiredValidation" *ngIf="daytimeDirectivePickerModel.errors?.required || false">required</div>
+          <div *ngIf="daytimeDirectivePickerModel.errors?.format || false">format invalid</div>
+          <div *ngIf="daytimeDirectivePickerModel.errors?.minDate">minDate invalid</div>
+          <div *ngIf="daytimeDirectivePickerModel.errors?.maxDate">maxDate invalid</div>
         </div>
       </div>
     </form>
@@ -884,31 +926,6 @@
         </div>
       </div>
 
-      <div class="dp-option" *ngIf="isValidConfig('hideInputContainer')">
-        <span class="dp-option-header">
-          Hide Input Container (hideInputContainer):
-        </span>
-        <div class="dp-option-playground">
-          <label>Hidden
-            <input type="radio"
-                   id="hideInputRadio"
-                   [(ngModel)]="config.hideInputContainer"
-                   name="hideInputContainer"
-                   [value]="true"
-                   (ngModelChange)="configChanged('hideInputContainer', 'hidden')">
-          </label>
-          <label>Shown
-            <input type="radio"
-                   id="showInputRadio"
-                   [(ngModel)]="config.hideInputContainer"
-                   name="hideInputContainer"
-                   [value]="false"
-                   (ngModelChange)="configChanged('hideInputContainer', 'shown')">
-          </label>
-        </div>
-      </div>
-
-
       <div class="dp-option" *ngIf="isValidConfig('showNearMonthDays')">
         <span class="dp-option-header">
           Show near month days (showNearMonthDays):
@@ -1218,20 +1235,6 @@
                  type="text"
                  [(ngModel)]="config.multipleYearsNavigateBy"
                  (change)="configChanged('multipleYearsNavigateBy', config.multipleYearsNavigateBy)">
-        </div>
-      </div>
-
-
-      <div class="dp-option" *ngIf="isValidConfig('returnedValueType')">
-        <span class="dp-option-header">
-          Returned Value Type (returnedValueType):
-        </span>
-        <div class="dp-option-playground">
-          <select id="returnedValueType"
-                  [(ngModel)]="config.returnedValueType"
-                  (change)="configChanged('returnedValueType', config.returnedValueType)">
-            <option *ngFor="let type of dateTypes" [value]="type.value">{{type.name}}</option>
-          </select>
         </div>
       </div>
     </div>

--- a/src/app/demo/demo/demo.component.less
+++ b/src/app/demo/demo/demo.component.less
@@ -9,6 +9,7 @@
   @stickyHeight: 120px;
   @stickyHeightInlineDay: 340px;
   @stickyHeightInlineMonth: 280px;
+  @stickyHeightInlineYear: 280px;
   @stickyHeightInlineTime: 180px;
   @stickyHeightInlineDayTime: 420px;
   @menuWidth: 200px;
@@ -94,6 +95,10 @@
 
     &.dp-inline-month {
       height: @stickyHeightInlineMonth;
+    }
+
+    &.dp-inline-year {
+      height: @stickyHeightInlineYear;
     }
 
     &.dp-inline-time {

--- a/src/app/demo/demo/demo.component.ts
+++ b/src/app/demo/demo/demo.component.ts
@@ -2,17 +2,15 @@ import debounce from '../../common/decorators/decorators';
 import {IDatePickerConfig} from '../../date-picker/date-picker-config.model';
 import {DatePickerComponent} from '../../date-picker/date-picker.component';
 import {DatePickerDirective} from '../../date-picker/date-picker.directive';
-import {Component, HostListener, ViewChild} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, ViewChild} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
 import * as moment from 'moment';
 import {Moment} from 'moment';
 import {GaService} from '../services/ga/ga.service';
-import {ECalendarValue} from '../../common/types/calendar-value-enum';
 
 const GLOBAL_OPTION_KEYS = [
   'theme',
-  'locale',
-  'returnedValueType'
+  'locale'
 ];
 const PICKER_OPTION_KEYS = [
   'apiclose',
@@ -28,8 +26,7 @@ const PICKER_OPTION_KEYS = [
   'onOpenDelay',
   'opens',
   'placeholder',
-  'required',
-  'hideInputContainer'
+  'required'
 ];
 const DAY_PICKER_DIRECTIVE_OPTION_KEYS = [
   'allowMultiSelect',
@@ -47,6 +44,18 @@ const DAY_TIME_PICKER_OPTION_KEYS = [
 ];
 const TIME_PICKER_OPTION_KEYS = [
   ...PICKER_OPTION_KEYS
+];
+const YEAR_CALENDAR_OPTION_KEYS = [
+  'minValidation',
+  'maxValidation',
+  'required',
+  'max',
+  'min',
+  'yearBtnFormat',
+  'multipleYearsNavigateBy',
+  'showMultipleYearsNavigation',
+  'yearFormat',
+  ...GLOBAL_OPTION_KEYS
 ];
 const MONTH_CALENDAR_OPTION_KEYS = [
   'minValidation',
@@ -104,7 +113,8 @@ const DAY_TIME_CALENDAR_OPTION_KEYS = [
   selector: 'dp-demo',
   templateUrl: './demo.component.html',
   entryComponents: [DatePickerComponent],
-  styleUrls: ['./demo.component.less']
+  styleUrls: ['./demo.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DemoComponent {
   showDemo: boolean = true;
@@ -140,28 +150,6 @@ export class DemoComponent {
   validationMaxTime: Moment;
   placeholder: string = 'Choose a date...';
   displayDate: Moment;
-  dateTypes: {name: string, value: ECalendarValue}[] = [
-    {
-      name: 'Guess',
-      value: null
-    },
-    {
-      name: ECalendarValue[ECalendarValue.Moment],
-      value: ECalendarValue.Moment
-    },
-    {
-      name: ECalendarValue[ECalendarValue.MomentArr],
-      value: ECalendarValue.MomentArr
-    },
-    {
-      name: ECalendarValue[ECalendarValue.String],
-      value: ECalendarValue.String
-    },
-    {
-      name: ECalendarValue[ECalendarValue.StringArr],
-      value: ECalendarValue.StringArr
-    }
-  ];
 
   formGroup: FormGroup = new FormGroup({
     datePicker: new FormControl({value: this.date, disabled: this.disabled}, [
@@ -198,6 +186,7 @@ export class DemoComponent {
     showGoToCurrent: true,
     dayBtnFormat: 'DD',
     monthBtnFormat: 'MMM',
+    yearBtnFormat: 'YYYY',
     hours12Format: 'hh',
     hours24Format: 'HH',
     meridiemFormat: 'A',
@@ -210,13 +199,12 @@ export class DemoComponent {
     timeSeparator: ':',
     multipleYearsNavigateBy: 10,
     showMultipleYearsNavigation: false,
-    locale: 'en',
-    hideInputContainer: false,
-    returnedValueType: ECalendarValue.String
+    locale: 'en'
   };
   isAtTop: boolean = true;
 
-  constructor(private gaService: GaService) {
+  constructor(private gaService: GaService,
+              private cd: ChangeDetectorRef) {
   }
 
   @HostListener('document:scroll')
@@ -247,7 +235,7 @@ export class DemoComponent {
 
   configChanged(change: string = 'N/A', value: any = 'N/A') {
     this.config = {...this.config};
-
+    this.cd.markForCheck();
     this.gaService.emitEvent('ConfigChange', change, value);
 
     if (change === 'locale') {
@@ -291,6 +279,10 @@ export class DemoComponent {
         return [
             ...MONTH_CALENDAR_OPTION_KEYS
           ].indexOf(key) > -1;
+      case 'yearInline':
+            return [
+                ...YEAR_CALENDAR_OPTION_KEYS
+              ].indexOf(key) > -1;
       case 'timeInline':
         return [
             ...TIME_SELECT_OPTION_KEYS
@@ -305,7 +297,7 @@ export class DemoComponent {
             ...DAY_CALENDAR_OPTION_KEYS
           ].indexOf(key) > -1;
       case 'dayDirective':
-      case 'dayDirectiveReactiveMenu':
+      case 'dayDirectiveReactive':
         return [
             ...DAY_PICKER_DIRECTIVE_OPTION_KEYS,
             ...DAY_CALENDAR_OPTION_KEYS
@@ -315,6 +307,11 @@ export class DemoComponent {
             ...DAY_PICKER_OPTION_KEYS,
             ...MONTH_CALENDAR_OPTION_KEYS
           ].indexOf(key) > -1;
+     case 'yearPicker':
+            return [
+                ...DAY_PICKER_OPTION_KEYS,
+                ...YEAR_CALENDAR_OPTION_KEYS
+              ].indexOf(key) > -1;
       case 'monthDirective':
         return [
             ...DAY_PICKER_DIRECTIVE_OPTION_KEYS,
@@ -346,12 +343,14 @@ export class DemoComponent {
       case 'dayPicker':
       case 'dayInline':
       case 'dayDirective':
-      case 'dayDirectiveReactiveMenu':
+      case 'dayDirectiveReactive':
         return 'DD-MM-YYYY';
       case 'monthPicker':
       case 'monthInline':
       case 'monthDirective':
         return 'MMM, YYYY';
+      case 'yearPicker':
+        return 'YYYY';
       case 'timePicker':
       case 'timeInline':
       case 'timeDirective':

--- a/src/app/year-calendar/year-calendar-config.ts
+++ b/src/app/year-calendar/year-calendar-config.ts
@@ -1,0 +1,16 @@
+import {locale, Moment} from 'moment';
+import {ICalendar} from '../common/models/calendar.model';
+
+export interface IYearCalendarConfig extends ICalendar {
+  isYearDisabledCallback?: (date: Moment) => boolean;
+  allowMultiSelect?: boolean;
+  yearFormat?: string;
+  yearFormatter?: (month: Moment) => string;
+  format?: string;
+  isNavHeaderBtnClickable?: boolean;
+  yearBtnFormat?: string;
+  yearBtnFormatter?: (day: Moment) => string;
+  yearBtnCssClassCallback?: (day: Moment) => string;
+  multipleYearsNavigateBy?: number;
+  showMultipleYearsNavigation?: boolean;
+}

--- a/src/app/year-calendar/year-calendar.component.html
+++ b/src/app/year-calendar/year-calendar.component.html
@@ -1,0 +1,29 @@
+<div class="dp-year-calendar-container">
+  <dp-calendar-nav
+      [label]="getNavLabel()"
+      [showLeftNav]="shouldShowLeftNav()"
+      [showLeftSecondaryNav]="shouldShowLeftSecondaryNav()"
+      [showRightNav]="shouldShowRightNav()"
+      [showRightSecondaryNav]="shouldShowRightSecondaryNav()"
+      [isLabelClickable]="isNavHeaderBtnClickable()"
+      [theme]="theme"
+      (onLeftNav)="onLeftNav()"
+      (onLeftSecondaryNav)="onLeftSecondaryNav()"
+      (onRightNav)="onRightNav()"
+      (onRightSecondaryNav)="onRightSecondaryNav()"
+      (onLabelClick)="toggleCalendar()">
+  </dp-calendar-nav>
+
+  <div class="dp-calendar-wrapper">
+    <div class="dp-year-row" *ngFor="let yearRow of yearMatrix">
+      <button type="button"
+              class="dp-calendar-year"
+              *ngFor="let year of yearRow"
+              [disabled]="isDisabledYear(year)"
+              [ngClass]="getYearBtnCssClass(year)"
+              (click)="yearClicked(year)">
+        {{getYearBtnText(year)}}
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/year-calendar/year-calendar.component.less
+++ b/src/app/year-calendar/year-calendar.component.less
@@ -1,0 +1,66 @@
+@import '../common/styles/variables';
+
+& {
+  dp-year-calendar {
+    display: inline-block;
+
+    .dp-year-calendar-container {
+      background: @c-white;
+    }
+
+    .dp-calendar-wrapper {
+      border: 1px solid @c-black;
+    }
+
+    .dp-calendar-year {
+      box-sizing: border-box;
+      width: @basic-height * 7 / 4;
+      height: @basic-height * 7 / 4;
+      cursor: pointer;
+
+      &.dp-selected {
+        background: @c-primary;
+        color: @c-white;
+      }
+    }
+
+    &.dp-material {
+      .dp-calendar-weekday {
+        height: @basic-height - 5px;
+        width: @basic-height;
+        line-height: @basic-height - 5px;
+        background: @c-light-gray;
+        border: 1px solid @c-light-gray;
+      }
+
+      .dp-calendar-wrapper {
+        border: 1px solid @c-light-gray;
+      }
+
+      .dp-calendar-year {
+        box-sizing: border-box;
+        background: @c-white;
+        border-radius: 50%;
+        border: none;
+        outline: none;
+
+        &:hover {
+          background: @c-light-gray;
+        }
+      }
+
+      .dp-selected {
+        background: @c-primary;
+        color: @c-white;
+
+        &:hover {
+          background: @c-primary;
+        }
+      }
+
+      .dp-current-year {
+        border: 1px solid @c-primary;
+      }
+    }
+  }
+}

--- a/src/app/year-calendar/year-calendar.component.spec.ts
+++ b/src/app/year-calendar/year-calendar.component.spec.ts
@@ -1,0 +1,80 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {YearCalendarComponent} from './year-calendar.component';
+import {UtilsService} from '../common/services/utils/utils.service';
+import {CalendarNavComponent} from '../calendar-nav/calendar-nav.component';
+import {YearCalendarService} from './year-calendar.service';
+import * as moment from 'moment';
+import {IYear} from './year.model';
+import {Moment} from 'moment';
+
+describe('Component: YearCalendarComponent', () => {
+  let component: YearCalendarComponent;
+  let fixture: ComponentFixture<YearCalendarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [YearCalendarComponent, CalendarNavComponent],
+      providers: [YearCalendarService, UtilsService]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(YearCalendarComponent);
+    component = fixture.componentInstance;
+    component.config = componentyearCalendarService.getConfig({});
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should check getYearBtnText default value', () => {
+    expect(component.getYearBtnText({
+      date: moment('2017', 'YYYY')
+    } as IYear)).toEqual('2017');
+  });
+
+  describe('should have the right CSS classes for', () => {
+    const defaultYear: IYear = {
+      date: undefined,
+      selected: false,
+      currentYear: false
+    };
+    const defaultCssClasses: { [klass: string]: boolean } = {
+      'dp-selected': false,
+      'dp-current-year': false
+    };
+
+    it('the selected year', () => {
+      expect(component.getYearBtnCssClass({
+        ...defaultYear,
+        selected: true
+      } as IYear)).toEqual({
+        ...defaultCssClasses,
+        'dp-selected': true
+      });
+    });
+
+    it('the current year', () => {
+      expect(component.getYearBtnCssClass({
+        ...defaultYear,
+        currentYear: true
+      } as IYear)).toEqual({
+        ...defaultCssClasses,
+        'dp-current-year': true
+      });
+    });
+
+    it('custom days', () => {
+      component.componentConfig.yearBtnCssClassCallback = (day: Moment) => 'custom-class';
+
+      expect(component.getYearBtnCssClass({
+        ...defaultYear
+      } as IYear)).toEqual({
+        ...defaultCssClasses,
+        'custom-class': true
+      });
+    });
+  });
+});

--- a/src/app/year-calendar/year-calendar.component.ts
+++ b/src/app/year-calendar/year-calendar.component.ts
@@ -96,7 +96,6 @@ export class YearCalendarComponent implements OnInit, OnChanges, ControlValueAcc
   }
 
   init() {
-    console.log("year init");
     this.componentConfig = this.yearCalendarService.getConfig(this.config);
     this.selected = this.selected || [];
     this.currentDateView = this.displayDate

--- a/src/app/year-calendar/year-calendar.component.ts
+++ b/src/app/year-calendar/year-calendar.component.ts
@@ -1,0 +1,238 @@
+import {ECalendarValue} from '../common/types/calendar-value-enum';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  forwardRef,
+  HostBinding,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewEncapsulation
+} from '@angular/core';
+import {IYear} from './year.model';
+import {YearCalendarService} from './year-calendar.service';
+import {Moment} from 'moment';
+import {IYearCalendarConfig} from './year-calendar-config';
+import {
+  ControlValueAccessor,
+  FormControl,
+  NG_VALIDATORS,
+  NG_VALUE_ACCESSOR,
+  ValidationErrors,
+  Validator
+} from '@angular/forms';
+import {CalendarValue} from '../common/types/calendar-value';
+import {UtilsService} from '../common/services/utils/utils.service';
+
+@Component({
+  selector: 'dp-year-calendar',
+  templateUrl: 'year-calendar.component.html',
+  styleUrls: ['year-calendar.component.less'],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    YearCalendarService,
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => YearCalendarComponent),
+      multi: true
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => YearCalendarComponent),
+      multi: true
+    }
+  ]
+})
+export class YearCalendarComponent implements OnInit, OnChanges, ControlValueAccessor, Validator {
+  @Input() config: IYearCalendarConfig;
+  @Input() displayDate: Moment;
+  @Input() minDate: Moment;
+  @Input() maxDate: Moment;
+  @HostBinding('class') @Input() theme: string;
+  @Output() onSelect: EventEmitter<IYear> = new EventEmitter();
+  @Output() onNavHeaderBtnClick: EventEmitter<null> = new EventEmitter();
+
+  isInited: boolean = false;
+  componentConfig: IYearCalendarConfig;
+  _selected: Moment[];
+  yearMatrix: IYear[][];
+  currentDateView: Moment;
+  inputValue: CalendarValue;
+  inputValueType: ECalendarValue;
+  validateFn: (inputVal: CalendarValue) => {[key: string]: any};
+
+  set selected(selected: Moment[]) {
+    this._selected = selected;
+    this.onChangeCallback(this.processOnChangeCallback(selected));
+  }
+
+  get selected(): Moment[] {
+    return this._selected;
+  }
+
+  constructor(public yearCalendarService: YearCalendarService,
+              public utilsService: UtilsService) {
+  }
+
+  ngOnInit() {
+    this.isInited = true;
+    this.init();
+    this.initValidators();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.isInited) {
+      const {minDate, maxDate} = changes;
+      this.init();
+
+      if (minDate || maxDate) {
+        this.initValidators();
+      }
+    }
+  }
+
+  init() {
+    console.log("year init");
+    this.componentConfig = this.yearCalendarService.getConfig(this.config);
+    this.selected = this.selected || [];
+    this.currentDateView = this.displayDate
+      ? this.displayDate
+      : this.utilsService
+        .getDefaultDisplayDate(this.currentDateView, this.selected, this.componentConfig.allowMultiSelect);
+    this.yearMatrix = this.yearCalendarService.generateYear(this.currentDateView, this.selected);
+    this.inputValueType = this.utilsService.getInputType(this.inputValue, this.componentConfig.allowMultiSelect);
+  }
+
+  writeValue(value: CalendarValue): void {
+    this.inputValue = value;
+
+    if (value) {
+      this.selected = this.utilsService
+        .convertToMomentArray(value, this.componentConfig.format, this.componentConfig.allowMultiSelect);
+      this.yearMatrix = this.yearCalendarService.generateYear(this.currentDateView, this.selected);
+      this.inputValueType = this.utilsService.getInputType(this.inputValue, this.componentConfig.allowMultiSelect);
+    }
+  }
+
+  registerOnChange(fn: any): void {
+    this.onChangeCallback = fn;
+  }
+
+  onChangeCallback(_: any) {
+  };
+
+  registerOnTouched(fn: any): void {
+  }
+
+  validate(formControl: FormControl): ValidationErrors | any {
+    if (this.minDate || this.maxDate) {
+      return this.validateFn(formControl.value);
+    } else {
+      return () => null;
+    }
+  }
+
+  processOnChangeCallback(value: Moment[]): CalendarValue {
+    return this.utilsService.convertFromMomentArray(this.componentConfig.format, value, this.inputValueType);
+  }
+
+  initValidators() {
+    this.validateFn = this.validateFn = this.utilsService.createValidator(
+      {minDate: this.minDate, maxDate: this.maxDate}, this.componentConfig.format, 'month');
+
+    this.onChangeCallback(this.processOnChangeCallback(this.selected));
+  }
+
+  isDisabledYear(year: IYear): boolean {
+    return this.yearCalendarService.isYearDisabled(year, this.componentConfig);
+  }
+
+  yearClicked(year: IYear) {
+    this.selected = this.utilsService
+      .updateSelected(this.componentConfig.allowMultiSelect, this.selected, year, 'year');
+    this.yearMatrix = this.yearCalendarService
+      .generateYear(this.currentDateView, this.selected);
+    this.onSelect.emit(year);
+  }
+
+  getNavLabel(): string {
+    return this.yearCalendarService.getHeaderLabel(this.componentConfig, this.currentDateView);
+  }
+
+  onLeftNav() {
+    this.currentDateView = this.currentDateView.subtract(12, 'year');
+    this.yearMatrix = this.yearCalendarService.generateYear(this.currentDateView, this.selected);
+  }
+
+  onLeftSecondaryNav() {
+    let navigateBy = this.componentConfig.multipleYearsNavigateBy;
+    const isOutsideRange = this.componentConfig.min &&
+      this.currentDateView.year() - this.componentConfig.min.year() < navigateBy;
+    if (isOutsideRange) {
+      navigateBy = this.currentDateView.year() - this.componentConfig.min.year();
+    }
+    this.currentDateView = this.currentDateView.subtract(navigateBy, 'year');
+    this.yearMatrix = this.yearCalendarService.generateYear(this.currentDateView, this.selected);
+  }
+
+  onRightNav() {
+    this.currentDateView.add(12, 'year');
+    this.yearMatrix = this.yearCalendarService.generateYear(this.currentDateView, this.selected);
+  }
+
+  onRightSecondaryNav() {
+    let navigateBy = this.componentConfig.multipleYearsNavigateBy;
+    const isOutsideRange = this.componentConfig.max &&
+      this.componentConfig.max.year() - this.currentDateView.year() < navigateBy;
+    if (isOutsideRange) {
+      navigateBy = this.componentConfig.max.year() - this.currentDateView.year();
+    }
+    this.currentDateView.add(navigateBy, 'year');
+    this.yearMatrix = this.yearCalendarService.generateYear(this.currentDateView, this.selected);
+  }
+
+  shouldShowLeftNav(): boolean {
+    return this.yearCalendarService.shouldShowLeft(this.componentConfig.min, this.currentDateView);
+  }
+
+  shouldShowLeftSecondaryNav(): boolean {
+    return this.componentConfig.showMultipleYearsNavigation && this.shouldShowLeftNav();
+  }
+
+  shouldShowRightNav(): boolean {
+    return this.yearCalendarService.shouldShowRight(this.componentConfig.max, this.currentDateView);
+  }
+
+  shouldShowRightSecondaryNav(): boolean {
+    return this.componentConfig.showMultipleYearsNavigation && this.shouldShowRightNav();
+  }
+
+  isNavHeaderBtnClickable(): boolean {
+    return this.componentConfig.isNavHeaderBtnClickable;
+  }
+
+  toggleCalendar() {
+    this.onNavHeaderBtnClick.emit();
+  }
+
+  getYearBtnText(year: IYear): string {
+    return this.yearCalendarService.getYearBtnText(this.componentConfig, year.date);
+  }
+
+  getYearBtnCssClass(year: IYear): {[klass: string]: boolean} {
+    const cssClass: {[klass: string]: boolean} = {
+      'dp-selected': year.selected,
+      'dp-current-year': year.currentYear
+    };
+    const customCssClass: string = this.yearCalendarService.getYearBtnCssClass(this.componentConfig, year.date);
+    if (customCssClass) {
+      cssClass[customCssClass] = true;
+    }
+
+    return cssClass;
+  }
+}

--- a/src/app/year-calendar/year-calendar.service.spec.ts
+++ b/src/app/year-calendar/year-calendar.service.spec.ts
@@ -1,0 +1,77 @@
+import {inject, TestBed} from '@angular/core/testing';
+import * as moment from 'moment';
+import {UtilsService} from '../common/services/utils/utils.service';
+import {YearCalendarService} from './year-calendar.service';
+import {IYear} from './year.model';
+
+describe('Service: YearCalendarService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [YearCalendarService, UtilsService]
+    });
+  });
+
+/*
+  it('should check the generateYear method', inject([YearCalendarService], (service: YearCalendarService) => {
+    const year = moment('14-01-1987', 'DD-MM-YYYY');
+    const selected = moment('14-01-1987', 'DD-MM-YYYY');
+    const genYear = service.generateYear(year, [selected]);
+
+    const current = year.clone().startOf('year');
+    genYear.forEach((row) => {
+      row.forEach((month) => {
+        expect(month.date.isSame(current, 'month')).toBe(true);
+        if (month.date.format('MMM') === 'Jan') {
+          expect(month.selected).toBe(true);
+        } else {
+          expect(month.selected).toBe(false);
+        }
+        expect(month.currentMonth).toBe(false);
+
+        current.add(1, 'month');
+      });
+    });
+  }));
+
+  it('should check the isDateDisabled method', inject([YearCalendarService], (service: YearCalendarService) => {
+    const month: IMonth = {
+      date: moment('09-04-2017', 'DD-MM-YYYY'),
+      selected: false,
+      currentMonth: false
+    };
+    const config1: any = {
+      min: month.date.clone().subtract(1, 'month'),
+      max: month.date.clone().add(1, 'month')
+    };
+
+    expect(service.isMonthDisabled(month, config1)).toBe(false);
+    month.date.subtract(1, 'month');
+    expect(service.isMonthDisabled(month, config1)).toBe(false);
+    month.date.subtract(1, 'month');
+    expect(service.isMonthDisabled(month, config1)).toBe(true);
+    month.date.add(3, 'month');
+    expect(service.isMonthDisabled(month, config1)).toBe(false);
+    month.date.add(1, 'month');
+    expect(service.isMonthDisabled(month, config1)).toBe(true);
+  }));
+
+  it('should check getDayBtnText method',
+    inject([MonthCalendarService],
+      (service: MonthCalendarService) => {
+        const date = moment('05-04-2017', 'DD-MM-YYYY');
+        expect(service.getMonthBtnText({monthBtnFormat: 'M'}, date)).toEqual('4');
+        expect(service.getMonthBtnText({monthBtnFormat: 'MM'}, date)).toEqual('04');
+        expect(service.getMonthBtnText({monthBtnFormatter: (m => 'bla')}, date)).toEqual('bla');
+        expect(service.getMonthBtnText({monthBtnFormat: 'MM', monthBtnFormatter: (m => m.format('M'))}, date))
+          .toEqual('4');
+      }));
+
+  it('should check getMonthBtnCssClass method',
+    inject([MonthCalendarService],
+      (service: MonthCalendarService) => {
+        const date = moment('05-04-2017', 'DD-MM-YYYY');
+        expect(service.getMonthBtnCssClass({}, date)).toEqual('');
+        expect(service.getMonthBtnCssClass({monthBtnCssClassCallback: (m => 'class1 class2')}, date)).toEqual('class1 class2');
+      }));
+      */
+});

--- a/src/app/year-calendar/year-calendar.service.ts
+++ b/src/app/year-calendar/year-calendar.service.ts
@@ -37,14 +37,14 @@ export class YearCalendarService {
 
     return this.utilsService.createArray(3).map(() => {
       return this.utilsService.createArray(4).map(() => {
-        const year = {
+        const yearObj = {
           date: index.clone(),
           selected: !!selected.find(s => index.isSame(s, 'year')),
           currentYear: index.isSame(moment(), 'year')
         };
 
         index.add(1, 'year');
-        return year;
+        return yearObj;
       });
     });
   }
@@ -77,7 +77,6 @@ export class YearCalendarService {
     if (config.yearBtnFormatter) {
       return config.yearBtnFormatter(year);
     }
-    console.log("getYearBtnText(" + year + ") format: " + config.yearBtnFormat);
     return year.format(config.yearBtnFormat);
   }
 

--- a/src/app/year-calendar/year-calendar.service.ts
+++ b/src/app/year-calendar/year-calendar.service.ts
@@ -1,0 +1,91 @@
+import {Injectable} from '@angular/core';
+import * as moment from 'moment';
+import {Moment} from 'moment';
+import {UtilsService} from '../common/services/utils/utils.service';
+import {IYear} from './year.model';
+import {IYearCalendarConfig} from './year-calendar-config';
+
+@Injectable()
+export class YearCalendarService {
+  readonly DEFAULT_CONFIG: IYearCalendarConfig = {
+    allowMultiSelect: false,
+    yearFormat: 'YYYY',
+    format: 'YYYY',
+    isNavHeaderBtnClickable: false,
+    yearBtnFormat: 'YYYY',
+    locale: 'en',
+    multipleYearsNavigateBy: 10,
+    showMultipleYearsNavigation: false
+  };
+
+  constructor(private utilsService: UtilsService) {
+  }
+
+  getConfig(config: IYearCalendarConfig): IYearCalendarConfig {
+    const _config = {
+      ...this.DEFAULT_CONFIG,
+      ...this.utilsService.clearUndefined(config)
+    };
+
+    moment.locale(_config.locale);
+
+    return _config;
+  }
+
+  generateYear(year: Moment, selected: Moment[] = null): IYear[][] {
+    const index = year.clone().startOf('year');
+
+    return this.utilsService.createArray(3).map(() => {
+      return this.utilsService.createArray(4).map(() => {
+        const year = {
+          date: index.clone(),
+          selected: !!selected.find(s => index.isSame(s, 'year')),
+          currentYear: index.isSame(moment(), 'year')
+        };
+
+        index.add(1, 'year');
+        return year;
+      });
+    });
+  }
+
+  isYearDisabled(year: IYear, config: IYearCalendarConfig) {
+    if (config.min && year.date.isBefore(config.min, 'year')) {
+      return true;
+    }
+
+    return !!(config.max && year.date.isAfter(config.max, 'year'));
+  }
+
+  shouldShowLeft(min: Moment, currentYearView: Moment): boolean {
+    return min ? min.isBefore(currentYearView, 'year') : true;
+  }
+
+  shouldShowRight(max: Moment, currentYearView: Moment): boolean {
+    return max ? max.isAfter(currentYearView, 'year') : true;
+  }
+
+  getHeaderLabel(config: IYearCalendarConfig, year: Moment): string {
+    if (config.yearFormatter) {
+      return config.yearFormatter(year);
+    }
+
+    return year.format(config.yearFormat);
+  }
+
+  getYearBtnText(config: IYearCalendarConfig, year: Moment): string {
+    if (config.yearBtnFormatter) {
+      return config.yearBtnFormatter(year);
+    }
+    console.log("getYearBtnText(" + year + ") format: " + config.yearBtnFormat);
+    return year.format(config.yearBtnFormat);
+  }
+
+  getYearBtnCssClass(config: IYearCalendarConfig, year: Moment): string {
+    if (config.yearBtnCssClassCallback) {
+      return config.yearBtnCssClassCallback(year);
+    }
+
+    return '';
+  }
+}

--- a/src/app/year-calendar/year.model.ts
+++ b/src/app/year-calendar/year.model.ts
@@ -1,0 +1,5 @@
+import {IDate} from '../common/models/date.model';
+
+export interface IYear extends IDate {
+  currentYear?: boolean;
+}


### PR DESCRIPTION
I've modified the month-picker into a year-picker, in its own, separate directory.
I hope I've configured the new calendar mode correctly in the overall module setup. I have only created the `dp-year-calendar` directive, and I have _not_ modified `date-picker.component.ts` or `date-picker.service.ts`, which I have a feeling I should have. However, the year picker works on the demo page, so I think this is a good start!