### PR TITLE
IE10 compatibility: use css 'display' to hide/display, html5 hidden not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,3 +418,15 @@ In order to provide configurations to the date-picker you need to pass it to the
 ```
 
 The `IDatePickerDirectiveConfig` is identical to [`IDatePickerConfig`](#configuration) above except that it lacks the `showGoToCurrent` property.
+
+## Compatibility
+
+### Internet Explorer 10:
+
+Internet explorer 10 doesn't support hidden attribut, but you can use a css rule on `data-hidden` to hide date picker components:
+
+```css
+[data-hidden="true"] {
+  display: none !important;
+}
+```

--- a/src/app/calendar-nav/calendar-nav.component.html
+++ b/src/app/calendar-nav/calendar-nav.component.html
@@ -1,11 +1,13 @@
 <div class="dp-calendar-nav-container">
   <div class="dp-nav-header">
     <span [hidden]="isLabelClickable"
+          [attr.data-hidden]="isLabelClickable"
           [innerText]="label">
     </span>
     <button type="button"
             class="dp-nav-header-btn"
             [hidden]="!isLabelClickable"
+            [attr.data-hidden]="!isLabelClickable"
             (click)="labelClicked()"
             [innerText]="label">
     </button>
@@ -22,6 +24,7 @@
       <button type="button"
               class="dp-calendar-nav-left"
               [hidden]="!showLeftNav"
+              [attr.data-hidden]="!showLeftNav"
               [disabled]="leftNavDisabled"
               (click)="leftNavClicked()">
       </button>
@@ -35,6 +38,7 @@
       <button type="button"
               class="dp-calendar-nav-right"
               [hidden]="!showRightNav"
+              [attr.data-hidden]="!showRightNav"
               [disabled]="rightNavDisabled"
               (click)="rightNavClicked()">
       </button>

--- a/src/app/date-picker/date-picker.component.html
+++ b/src/app/date-picker/date-picker.component.html
@@ -1,5 +1,7 @@
 <div [ngClass]="{'dp-open': areCalendarsShown}">
-  <div [hidden]="componentConfig.hideInputContainer" class="dp-input-container">
+  <div class="dp-input-container"
+       [hidden]="componentConfig.hideInputContainer"
+       [attr.data-hidden]="componentConfig.hideInputContainer">
     <input type="text"
            class="dp-picker-input"
            [placeholder]="placeholder"
@@ -12,7 +14,8 @@
   <div #container>
     <div class="dp-popup {{theme}}"
          [ngSwitch]="mode"
-         [hidden]="!_areCalendarsShown">
+         [hidden]="!_areCalendarsShown"
+         [attr.data-hidden]="!_areCalendarsShown">
       <dp-day-calendar #dayCalendar
                        *ngSwitchCase="'day'"
                        [config]="dayCalendarConfig"


### PR DESCRIPTION
Use css 'display' to hide/display components via a custom attribut 'data-hidden'. 'hidden' html5 attribut is not supported by IE10.