### PR TITLE
For issue #297 - Prevent overriding of form control value from input updates

### DIFF
--- a/e2e/current-btn-e2e.spec.ts
+++ b/e2e/current-btn-e2e.spec.ts
@@ -19,8 +19,8 @@ describe('dpDayPicker dayPicker', () => {
 
     const commonDayCalendar = (menu: ElementFinder, input: ElementFinder) => {
       menu.click();
-      input.click();
       page.showGoToCurrentRadio.click();
+      input.click();
       expect(page.currentLocationBtn.isPresent()).toBe(true);
       expect(page.dayCalendarNavHeaderBtn.getText()).toEqual(currentMonth);
       page.dayCalendarLeftNavBtn.click();
@@ -45,8 +45,8 @@ describe('dpDayPicker dayPicker', () => {
 
     const commonMonth = (menu: ElementFinder, input?: ElementFinder) => {
       menu.click();
-      input.click();
       page.showGoToCurrentRadio.click();
+      input.click();
       expect(page.currentLocationBtn.isPresent()).toBe(true);
       expect(page.deyCalendarMonthNavHeader.getText()).toEqual(currentYear);
       page.monthCalendarLeftNavBtn.click();

--- a/e2e/datpicker-e2e.spec.ts
+++ b/e2e/datpicker-e2e.spec.ts
@@ -34,6 +34,7 @@ describe('dpDayPicker dayPicker', () => {
   it('should check that the onOpenDelay is working', () => {
     page.onOpenDelayInput.clear();
     page.onOpenDelayInput.sendKeys(1000);
+    page.scrollIntoView(page.openBtn);
     page.openBtn.click();
     expect(page.datePickerPopup.isDisplayed()).toBe(true);
     page.clickOnBody();

--- a/e2e/directive-e2e.spec.ts
+++ b/e2e/directive-e2e.spec.ts
@@ -1,6 +1,7 @@
 import {DemoPage} from './app.po';
 import {browser} from 'protractor';
 import * as moment from 'moment';
+import {Key} from 'selenium-webdriver';
 
 describe('dpDayPicker directive', () => {
   let page: DemoPage;
@@ -52,5 +53,16 @@ describe('dpDayPicker directive', () => {
     browser.waitForAngularEnabled(true);
     browser.sleep(1000);
     expect(page.datePickerPopup.isDisplayed()).toBe(true);
+  });
+
+  it('should allow input to be modified from beginning', () => {
+    page.dayDirectiveInput.sendKeys('10-04-2017');
+    page.dayDirectiveInput.sendKeys(Key.CONTROL, Key.HOME);
+    page.dayDirectiveInput.sendKeys(Key.DELETE);
+    page.dayDirectiveInput.sendKeys('2');
+    expect(page.dayDirectiveInput.getAttribute('value')).toBe('20-04-2017');
+    expect(page.selectedDays.count()).toBe(1);
+    expect(page.selectedDays.first().getText()).toBe('20');
+    expect(page.dayCalendarNavHeaderBtn.getText()).toBe('Apr, 2017');
   });
 });

--- a/src/app/date-picker/date-picker.component.ts
+++ b/src/app/date-picker/date-picker.component.ts
@@ -129,7 +129,7 @@ export class DatePickerComponent implements OnChanges,
       .convertFromMomentArray(this.componentConfig.format, selected, ECalendarValue.StringArr))
       .join(', ');
     const val = this.processOnChangeCallback(selected);
-    this.onChangeCallback(val);
+    this.onChangeCallback(val, false);
     this.onChange.emit(val);
   }
 
@@ -247,7 +247,7 @@ export class DatePickerComponent implements OnChanges,
     this.onChangeCallback = fn;
   }
 
-  onChangeCallback(_: any) {
+  onChangeCallback(_: any, changedByInput: boolean) {
   };
 
   registerOnTouched(fn: any): void {
@@ -277,7 +277,7 @@ export class DatePickerComponent implements OnChanges,
         minTime: this.minTime,
         maxTime: this.maxTime
       }, this.componentConfig.format, this.mode);
-    this.onChangeCallback(this.processOnChangeCallback(this.selected));
+    this.onChangeCallback(this.processOnChangeCallback(this.selected), false);
   }
 
   ngOnInit() {
@@ -409,7 +409,7 @@ export class DatePickerComponent implements OnChanges,
     } else {
       this._selected = this.utilsService
         .getValidMomentArray(value, this.componentConfig.format);
-      this.onChangeCallback(this.processOnChangeCallback(value));
+      this.onChangeCallback(this.processOnChangeCallback(value), true);
     }
   }
 

--- a/src/app/date-picker/date-picker.directive.ts
+++ b/src/app/date-picker/date-picker.directive.ts
@@ -176,11 +176,11 @@ export class DatePickerDirective implements OnInit {
 
     let setup = true;
 
-    this.datePicker.registerOnChange((value) => {
+    this.datePicker.registerOnChange((value, changedByInput) => {
       if (value) {
         const isMultiselectEmpty = setup && Array.isArray(value) && !value.length;
 
-        if (!isMultiselectEmpty) {
+        if (!isMultiselectEmpty && !changedByInput) {
           this.formControl.control.setValue(this.datePicker.inputElementValue);
         }
       }
@@ -197,7 +197,9 @@ export class DatePickerDirective implements OnInit {
         if (errors.hasOwnProperty('format')) {
           const {given} = errors['format'];
           this.datePicker.inputElementValue = given;
-          this.formControl.control.setValue(given);
+          if (!changedByInput) {
+            this.formControl.control.setValue(given);
+          }
         }
 
         this.formControl.control.setErrors(errors);


### PR DESCRIPTION
A somewhat naive (but simple) approach to addressing issue #297.

Passing through a flag to the onChangeCallback to tell whether or not the form control value should be updated or not.