### PR TITLE
fix(date-picker): register onTouched callback on blurred

### DIFF
--- a/src/app/date-picker/date-picker.component.html
+++ b/src/app/date-picker/date-picker.component.html
@@ -8,6 +8,7 @@
            [ngModel]="inputElementValue"
            (ngModelChange)="onViewDateChange($event)"
            (focus)="inputFocused()"
+           (blur)="inputBlurred()"
            [readonly]="componentConfig.disableKeypress"
            [disabled]="disabled"/>
   </div>

--- a/src/app/date-picker/date-picker.component.spec.ts
+++ b/src/app/date-picker/date-picker.component.spec.ts
@@ -12,6 +12,7 @@ import {MonthCalendarComponent} from '../month-calendar/month-calendar.component
 import {DayCalendarService} from '../day-calendar/day-calendar.service';
 import {TimeSelectService} from '../time-select/time-select.service';
 import {UtilsService} from '../common/services/utils/utils.service';
+import {By} from '@angular/platform-browser';
 
 describe('Component: DatePickerComponent', () => {
   let component: DatePickerComponent;
@@ -76,5 +77,16 @@ describe('Component: DatePickerComponent', () => {
     spyOn(component.onGoToCurrent, 'emit');
     component.dayTimeCalendarRef.onGoToCurrent.emit();
     expect(component.onGoToCurrent.emit).toHaveBeenCalledWith();
+  });
+
+  it('should call onTouched when input is blurred', () => {
+    setComponentMode('day');
+    spyOn(component, 'onTouchedCallback');
+    component.registerOnTouched(component.onTouchedCallback);
+
+    const inputElement = fixture.debugElement.query(By.css('.dp-picker-input'));
+    inputElement.triggerEventHandler('blur', {});
+
+    expect(component.onTouchedCallback).toHaveBeenCalledWith();
   });
 });

--- a/src/app/date-picker/date-picker.component.ts
+++ b/src/app/date-picker/date-picker.component.ts
@@ -266,6 +266,11 @@ export class DatePickerComponent implements OnChanges,
   }
 
   registerOnTouched(fn: any): void {
+    this.onTouchedCallback = fn;
+  }
+
+  onTouchedCallback() {
+
   }
 
   validate(formControl: FormControl): ValidationErrors {
@@ -387,6 +392,10 @@ export class DatePickerComponent implements OnChanges,
       this.isFocusedTrigger = false;
       this.cd.markForCheck();
     }, this.componentConfig.onOpenDelay);
+  }
+
+  inputBlurred() {
+    this.onTouchedCallback();
   }
 
   showCalendars() {


### PR DESCRIPTION
The onTouched callback should be registered to the onBlur event handler of the input element.

Previous behaviour before this PR:
The className of `<dp-date-picker>` includes `ng-untouched` after the user has selected/input a date string.

Expected behaviour on this PR:
The className of `<dp-date-picker>` includes `ng-touched` after the user has selected/input a date string.