### PR TITLE
Use now Renderer2 to avoid future problems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-date-picker",
-  "version": "2.11.0",
+  "version": "2.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ng2-date-picker",
   "author": "Vlad Ioffe",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "license": "MIT",
   "main": "index.js",
   "scripts": {

--- a/src/app/date-picker/date-picker.component.ts
+++ b/src/app/date-picker/date-picker.component.ts
@@ -32,7 +32,7 @@ import {
   OnDestroy,
   OnInit,
   Output,
-  Renderer,
+  Renderer2,
   SimpleChanges,
   ViewChild,
   ViewEncapsulation
@@ -201,7 +201,7 @@ export class DatePickerComponent implements OnChanges,
   constructor(private readonly dayPickerService: DatePickerService,
               private readonly domHelper: DomHelper,
               private readonly elemRef: ElementRef,
-              private readonly renderer: Renderer,
+              private readonly renderer: Renderer2,
               private readonly utilsService: UtilsService,
               public readonly cd: ChangeDetectorRef) {
   }


### PR DESCRIPTION
We should use now `Renderer2` now and not `Renderer`. 
`Renderer` will be remove din Angular 9.