### PR TITLE
changing Moment import in time-select-config to avoid deep imports warning on v9

### DIFF
--- a/src/lib/time-select/time-select-config.model.ts
+++ b/src/lib/time-select/time-select-config.model.ts
@@ -1,4 +1,4 @@
-import {Moment} from 'moment/moment';
+import {Moment} from 'moment';
 import {ICalendar, ICalendarInternal} from '../common/models/calendar.model';
 import {ECalendarValue} from '../common/types/calendar-value-enum';
 


### PR DESCRIPTION
Opened an issue that points to this PR. Please let me know if I missed something from the contributing guidelines 😄 