### PR TITLE
Fix arrow positions when min/max date are reached.

### DIFF
--- a/src/lib/calendar-nav/calendar-nav.component.html
+++ b/src/lib/calendar-nav/calendar-nav.component.html
@@ -14,10 +14,12 @@
   </div>
 
   <div class="dp-nav-btns-container">
-    <div class="dp-calendar-nav-container-left">
+    <div class="dp-calendar-nav-container-left" [ngClass]="{'dp-calendar-nav-container-two-buttons': showLeftSecondaryNav}">
       <button (click)="leftSecondaryNavClicked()"
               *ngIf="showLeftSecondaryNav"
+              [attr.data-hidden]="!showLeftNav"
               [disabled]="leftSecondaryNavDisabled"
+              [hidden]="!showLeftNav"
               class="dp-calendar-secondary-nav-left"
               type="button">
       </button>
@@ -34,7 +36,7 @@
             class="dp-current-location-btn"
             type="button">
     </button>
-    <div class="dp-calendar-nav-container-right">
+    <div class="dp-calendar-nav-container-right" [ngClass]="{'dp-calendar-nav-container-two-buttons': showRightSecondaryNav}">
       <button (click)="rightNavClicked()"
               [attr.data-hidden]="!showRightNav"
               [disabled]="rightNavDisabled"
@@ -44,7 +46,9 @@
       </button>
       <button (click)="rightSecondaryNavClicked()"
               *ngIf="showRightSecondaryNav"
+              [attr.data-hidden]="!showRightNav"
               [disabled]="rightSecondaryNavDisabled"
+              [hidden]="!showRightNav"
               class="dp-calendar-secondary-nav-right"
               type="button">
       </button>

--- a/src/lib/calendar-nav/calendar-nav.component.less
+++ b/src/lib/calendar-nav/calendar-nav.component.less
@@ -28,8 +28,13 @@
       display: inline-block;
     }
 
-    .dp-calendar-nav-container-left, .dp-calendar-nav-container-right {
+    .dp-calendar-nav-container-left,
+    .dp-calendar-nav-container-right {
       display: inline-block;
+      width: 16px;
+      &.dp-calendar-nav-container-two-buttons {
+        width: 36px;
+      }
     }
 
     .dp-calendar-nav-left,
@@ -41,12 +46,14 @@
       cursor: pointer;
     }
 
-    .dp-calendar-nav-left, .dp-calendar-nav-right {
+    .dp-calendar-nav-left,
+    .dp-calendar-nav-right {
       line-height: 0;
       .arrow(45deg);
     }
 
-    .dp-calendar-secondary-nav-left, .dp-calendar-secondary-nav-right {
+    .dp-calendar-secondary-nav-left,
+    .dp-calendar-secondary-nav-right {
       .double-arrow(45deg);
       padding: 0;
     }

--- a/src/lib/day-calendar/day-calendar.component.ts
+++ b/src/lib/day-calendar/day-calendar.component.ts
@@ -80,8 +80,8 @@ export class DayCalendarComponent implements OnInit, OnChanges, ControlValueAcce
     this.navLabel = this.dayCalendarService.getHeaderLabel(this.componentConfig, this._currentDateView);
     this.showLeftNav = this.dayCalendarService.shouldShowLeft(this.componentConfig.min, this.currentDateView);
     this.showRightNav = this.dayCalendarService.shouldShowRight(this.componentConfig.max, this.currentDateView);
-    this.showSecondaryLeftNav = this.componentConfig.showSecondaryNavigationDayView && this.showLeftNav;
-    this.showSecondaryRightNav = this.componentConfig.showSecondaryNavigationDayView && this.showRightNav;
+    this.showSecondaryLeftNav = this.componentConfig.showSecondaryNavigationDayView;
+    this.showSecondaryRightNav = this.componentConfig.showSecondaryNavigationDayView;
   }
   ;
 

--- a/src/lib/month-calendar/month-calendar.component.ts
+++ b/src/lib/month-calendar/month-calendar.component.ts
@@ -77,8 +77,8 @@ export class MonthCalendarComponent implements OnInit, OnChanges, ControlValueAc
     this.navLabel = this.monthCalendarService.getHeaderLabel(this.componentConfig, this.currentDateView);
     this.showLeftNav = this.monthCalendarService.shouldShowLeft(this.componentConfig.min, this._currentDateView);
     this.showRightNav = this.monthCalendarService.shouldShowRight(this.componentConfig.max, this.currentDateView);
-    this.showSecondaryLeftNav = this.componentConfig.showSecondaryNavigationMonthView && this.showLeftNav;
-    this.showSecondaryRightNav = this.componentConfig.showSecondaryNavigationMonthView && this.showRightNav;
+    this.showSecondaryLeftNav = this.componentConfig.showSecondaryNavigationMonthView;
+    this.showSecondaryRightNav = this.componentConfig.showSecondaryNavigationMonthView;
   }
 
   @Input() config: IMonthCalendarConfig;


### PR DESCRIPTION
Hey @vlio20,

Using the date-picker for a new website this week, I've noticed an annoying behavior, which also impacts my previous PR (#502):

1. When there is a max date, the "next" arrow disappears when you reach this date (that's ok).
But if you click "previous" arrow, the next arrow comes back, moving other buttons to the left.
So if you want to click twice the "previous" arrow, the 2nv click will be on the "current date" button, which is annoying for the user.
To solve this issue, I've just added a width to the button container (the button is 16px, so its parents would be 16px too).

2. Then checking what is the behavior with double arrows, there is an "*ngIf" on it, which was not consistent with the "simple" arrows one.
The "*ngIf" on the simple arrows only depends on the config. Then, the "hidden" attribute depends on the min/max date.
For double arrows, the "*ngIf" also took into account the min/max date, and no "hidden" attribute was used.
I've splitted it back to have the same behavior as the simple arrows.
Then I added a conditionnal class to the parent to have the correct width, depending on user config.

Please tell me what you think about that.