### PR TITLE
Fix: Update the broken url with current active url for How to Contribute in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 First, thank you for considering contributing to angular-datepicker! It's people like you that make the open source community such a great community! 😊
 
-We welcome any type of contribution, not only code. You can help with 
+We welcome any type of contribution, not only code. You can help with
 - **QA**: file bug reports, the more details you can give the better (e.g. screenshots with the console open)
 - **Marketing**: writing blog posts, howto's, printing stickers, ...
 - **Community**: presenting the project at meetups, organizing a dedicated meetup for the local community, ...
@@ -13,7 +13,7 @@ We welcome any type of contribution, not only code. You can help with
 
 ## Your First Contribution
 
-Working on your first Pull Request? You can learn how from this *free* series, [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
+Working on your first Pull Request? You can learn how from this *free* series, [How to Contribute to an Open Source Project on GitHub](https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github).
 
 ## Submitting code
 


### PR DESCRIPTION
Hi! I've updated the CONTRIBUTING.md to fix this issue https://github.com/vlio20/angular-datepicker/issues/605.

@vlio20 let me know if we want to add some extra reference for this?

Old broken link: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
Current active link: https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github

